### PR TITLE
Support empty arrays in SQL, since SQLite allows them

### DIFF
--- a/cjs/sql.js
+++ b/cjs/sql.js
@@ -12,7 +12,7 @@ const asParams = (template, ...values) => {
     else {
       if (isArray(values[i])) {
         t.push(...values[i].slice(1).map(_ => ','));
-        v.push(...values[i]);
+        v.push(...(values[i].length ? values[i] : ['']))
       }
       else
         v.push(values[i]);

--- a/esm/sql.js
+++ b/esm/sql.js
@@ -11,7 +11,7 @@ const asParams = (template, ...values) => {
     else {
       if (isArray(values[i])) {
         t.push(...values[i].slice(1).map(_ => ','));
-        v.push(...values[i]);
+        v.push(...(values[i].length ? values[i] : ['']))
       }
       else
         v.push(values[i]);

--- a/test/sql.js
+++ b/test/sql.js
@@ -15,3 +15,8 @@ console.assert(JSON.stringify(values) === '[4,"test"]');
 [template, values] = tag`SELECT * FROM ${asStatic('table')} WHERE id IN (${[5,6]}) OR name IN (${['A', 'B']})`;
 console.assert(template.join('?') === 'SELECT * FROM table WHERE id IN (?,?) OR name IN (?,?)');
 console.assert(JSON.stringify(values) === '[5,6,"A","B"]');
+
+// SQLite allows empty sets in WHERE ... IN statements
+[template, values] = tag`SELECT * FROM ${asStatic('table')} WHERE name IN (${[]})`;
+console.assert(template.join('?') === 'SELECT * FROM table WHERE name IN (?)');
+console.assert(JSON.stringify(values) === '[""]');


### PR DESCRIPTION
Per discussion in WebReflection/sqlite-tag-spawned#7.